### PR TITLE
Refactor some stuff and properly handle files with extensions.

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -306,7 +306,7 @@ impl Elf {
         Ok(())
     }
 
-    pub fn read(input: &mut File) -> Result<Self, Box<dyn Error>> {
+    pub fn read(input: impl Read + Seek) -> Result<Self, Box<dyn Error>> {
         let mut result = Elf::new();
         let mut r = ByteOrdered::runtime(input, Endianness::Little);
         let mut old_pos = 0;
@@ -514,7 +514,7 @@ impl Elf {
         return Ok(result);
     }
 
-    pub fn write(&mut self, output: &mut File) -> Result<(), Box<dyn Error>> {
+    pub fn write(&mut self, output: impl Write + Seek) -> Result<(), Box<dyn Error>> {
         let mut w = ByteOrdered::runtime(output, Endianness::Little);
         self.update()?;
 

--- a/src/int.rs
+++ b/src/int.rs
@@ -15,17 +15,9 @@ pub fn get_instructions(machine: MachineType, offset: u32) -> [u8; 16] {
             result[3] = actual[2];
             result[4] = actual[3];
 
-            result[5] = 0x90;
-            result[6] = 0x90;
-            result[7] = 0x90;
-            result[8] = 0x90;
-            result[9] = 0x90;
-            result[10] = 0x90;
-            result[11] = 0x90;
-            result[12] = 0x90;
-            result[13] = 0x90;
-            result[14] = 0x90;
-            result[15] = 0x90;
+            for i in 5..16 {
+                result[i] = 0x90;
+            }
         }
     }
 


### PR DESCRIPTION
This refactors some stuff to be nicer, such as using `impl Write` and `impl Read` instead of concrete `File` types.
This also properly handles files with extensions.

![emoticon-computer-icons-smiley-angry-emoji](https://github.com/marv7000/solink/assets/60669730/69ef7fbf-2cc2-4c20-9fe1-3c431be33cda)
